### PR TITLE
Make use of existing nix parameters

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
-nix-build hpc-nix.nix
-./result/bin/nix-build hpc-nix.nix
+nix-build hpc-nix.nix -o nix-intermediate
+./nix-intermediate/bin/nix-build hpc-nix.nix -o nix-final
+./nix-final/bin/nix copy ./nix-final --no-check-sigs --to /tmp/copy-me-to-server

--- a/hpc-nix.nix
+++ b/hpc-nix.nix
@@ -2,12 +2,10 @@ with (import ./nixpkgs {});
 
 let prefix = "/global/home/users/dbarter";
 in
-  nix.overrideAttrs (oldAttrs: rec {
-    configureFlags = [ "--with-store-dir=${prefix}/nix/store"
-                       "--localstatedir=${prefix}/nix/var"
-                       "--sysconfdir=${prefix}/nix/etc"
-                       "--enable-gc"
-                     ];
-
+  (nix.override {
+    storeDir = "${prefix}/nix/store";
+    stateDir = "${prefix}/nix/var";
+    confDir = "${prefix}/nix/etc";
+  }).overrideAttrs (oldAttrs: rec {
     patches = (oldAttrs.patches or []) ++ [./nfs.patch];
-      })
+  })


### PR DESCRIPTION
The nix derivation in nixpkgs is already parametrized by the store dir location. It's better to make use of that instead of manually using `overrideAttrs`, which cannot be assumed stable.